### PR TITLE
remove unnecessary print

### DIFF
--- a/StartInspection.py
+++ b/StartInspection.py
@@ -13,7 +13,7 @@ def is_bv_valid_for_plugin(bv: bn.BinaryView) -> bool:
     if bv.arch.name == "x86_64" or bv.arch.name == "x86":
         return True
     else:
-        print(f'ClassyPP: Executable CPU Arch is: {bv.arch.name}. This plugin supports only x86 32/64 bit executables.')
+        bn.log_debug(f'ClassyPP: Executable CPU Arch is: {bv.arch.name}. This plugin supports only x86 32/64 bit executables.')
         return False
 
 

--- a/StartInspection.py
+++ b/StartInspection.py
@@ -12,9 +12,6 @@ from .RttiInformation.VirtualTableInference import VirtualFunctionTable
 def is_bv_valid_for_plugin(bv: bn.BinaryView) -> bool:
     if bv.arch and (bv.arch.name == "x86_64" or bv.arch.name == "x86"):
         return True
-    else:
-        bn.log_debug(f'ClassyPP: Executable CPU Arch is: {bv.arch.name}. This plugin supports only x86 32/64 bit executables.')
-        return False
 
 
 def GetUserInputs() -> bool:

--- a/StartInspection.py
+++ b/StartInspection.py
@@ -10,7 +10,7 @@ from .RttiInformation.VirtualTableInference import VirtualFunctionTable
 
 
 def is_bv_valid_for_plugin(bv: bn.BinaryView) -> bool:
-    if bv.arch.name == "x86_64" or bv.arch.name == "x86":
+    if bv.arch and (bv.arch.name == "x86_64" or bv.arch.name == "x86"):
         return True
     else:
         bn.log_debug(f'ClassyPP: Executable CPU Arch is: {bv.arch.name}. This plugin supports only x86 32/64 bit executables.')


### PR DESCRIPTION
Convert an unnecessary print. Really should probably just be removed, but I changed it to a log_debug so if you really want to still see the message you can in debug mode.