### PR TITLE
Make regex strings raw strings

### DIFF
--- a/RttiInformation/ClassMemoryLayout/LayoutParser.py
+++ b/RttiInformation/ClassMemoryLayout/LayoutParser.py
@@ -60,7 +60,7 @@ def get_class_info(line: str) -> Tuple[str, int]:
 
 
 def get_layout_member_offset(line: str) -> int:
-    return int(re.search(f'\d+', line).group())
+    return int(re.search(r'\d+', line).group())
 
 
 def get_hierarchy_level(line: str) -> int:
@@ -73,7 +73,7 @@ def get_member_class_name(line: str) -> str:
 
 def get_data_member_info(line: str) -> Tuple[str, str]:
     if f'<alignment member>' in line:
-        return f'alignment_member', re.search(f'\d+', line).group()
+        return f'alignment_member', re.search(r'\d+', line).group()
     else:
         processed_line = line.split(f'|')[1].split()
         if len(processed_line) == 2:


### PR DESCRIPTION
Fixes python 3.12 warnings:

```
[Default] /home/dzervas/.binaryninja/repositories/community/plugins/CySHell_ClassyPP/RttiInformation/ClassMemoryLayout/LayoutParser.py:63: SyntaxWarning: invalid escape sequence '\d'
[Default]   return int(re.search(f'\d+', line).group())
[Default] /home/dzervas/.binaryninja/repositories/community/plugins/CySHell_ClassyPP/RttiInformation/ClassMemoryLayout/LayoutParser.py:76: SyntaxWarning: invalid escape sequence '\d'
[Default]   return f'alignment_member', re.search(f'\d+', line).group()
```